### PR TITLE
Fix composer-plugin-api dependency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": "^7.4.0",
         "ext-json": "*",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^2.1"
     },
     "require-dev": {
         "composer/composer": "1.10.10",
         "infection/infection": "^0.17.5",
         "mikey179/vfsstream": "^1.6",
         "phpro/grumphp": "^0.17.1 || ^0.19.0 || ^0.20.0",
-        "phpstan/phpstan": "^0.11.5 || ^0.12.0",
+        "phpstan/phpstan": "^0.12.0",
         "phpunit/phpunit": "^9.2",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/var-dumper": "^5.1",


### PR DESCRIPTION
## Description

- Upgrade `composer-plugin-api` dependency to fix following issue:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires composer-plugin-api ^1.1, found composer-plugin-api[2.1.0] but it does not match the constraint.
```

## Motivation and context

- Since the Composer v2 is latest stable version and released for about whiles, it should use `Composer V2` version.

## How has this been tested?

N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
